### PR TITLE
Update to version 2.1

### DIFF
--- a/src/main/java/com/clanevents/ClanEventsPanel.java
+++ b/src/main/java/com/clanevents/ClanEventsPanel.java
@@ -548,9 +548,7 @@ class ClanEventsPanel extends PluginPanel
 
                                         case 1:
                                             //The button's action
-                                            val2 = val2.toLowerCase();
-
-                                            switch(val2) {
+                                            switch(val2.toLowerCase()) {
                                                 case "hide":
                                                     createHideEvent(button);
                                                     setInvisible = true;

--- a/src/main/java/com/clanevents/ClanEventsPanel.java
+++ b/src/main/java/com/clanevents/ClanEventsPanel.java
@@ -145,7 +145,7 @@ class ClanEventsPanel extends PluginPanel
 
             case EVENTS:
                 icon = ImageUtil.loadImageResource(getClass(), "events.png");
-                dropdown.addItem(new ComboBoxIconEntry(new ImageIcon(icon), " Clan Events", "events"));
+                dropdown.addItem(new ComboBoxIconEntry(new ImageIcon(icon), " Active Clan Events", "events"));
                 break;
 
             case SOTW:

--- a/src/main/java/com/clanevents/config/EntrySelect.java
+++ b/src/main/java/com/clanevents/config/EntrySelect.java
@@ -34,10 +34,10 @@ public enum EntrySelect
 {
     NONE("None", 0),
     HOME("Home", 1),
-    SOTW("Past Skill of the Week", 2),
-    BOTW("Past Boss of the Week", 3),
-    EVENTS("Clan Events", 4),
-    HOF_OVERALL("Hall of Fame - Overall", 4),
+    EVENTS("Active Clan Events", 2),
+    SOTW("Past Skill of the Week", 3),
+    BOTW("Past Boss of the Week", 4),
+    HOF_OVERALL("Hall of Fame - Overall", 5),
     HOF_KC("Hall of Fame - KC", 6),
     HOF_PB("Hall of Fame - PB", 7);
 


### PR DESCRIPTION
Update version to 2.1. Update runelite version to 1.8.24.2. Remove "Past" from sotw and botw entries. Rename "Active Clan Events" entry to "Clan Hub". Rename "events.png" to "hub.png". Add keybind navigation. Add keybind configuration. Move JTable tooltip code to ColumnCellRenderer class. Fix tooltip bug where it wasn't disappearing when moving mouse off of it. Fix bug related to clicking on the plugin panel after the configuration changed by no longer removing it from the client toolbar. Change plugin panel priority from 7 to 5 to make it appear higher up on the toolbar.